### PR TITLE
Updated meta-inf delimiter

### DIFF
--- a/demo-content/404.md
+++ b/demo-content/404.md
@@ -1,6 +1,6 @@
-/*
+```metainf
 Title: Error 404
-*/
+```
 
 Error 404
 =========

--- a/demo-content/405.md
+++ b/demo-content/405.md
@@ -1,6 +1,6 @@
-/*
+```metainf
 Title: Error 405
-*/
+```
 
 Error 405
 =========

--- a/demo-content/500.md
+++ b/demo-content/500.md
@@ -1,6 +1,6 @@
-/*
+```metainf
 Title: Error 500
-*/
+```
 
 Error 500
 =========

--- a/demo-content/about/history.md
+++ b/demo-content/about/history.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: MDWeb History
 Nav Name: MDWeb History
 Description: The long and storied history of MDWeb
@@ -7,7 +7,7 @@ Order: 3
 Teaser: The long and storied history of MDWeb.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 MDWeb began out of my need for a framework to host a site for my 
 personal projects called lapinlabs.com. Over the past four years I went

--- a/demo-content/about/index.md
+++ b/demo-content/about/index.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: About MDWeb
 Nav Name: About MDWeb
 Description: All about MDWeb
@@ -6,7 +6,7 @@ Order: 1
 Teaser: What MDWeb is and how it came about.
 Sitemap Priority: 0.9
 Sitemap Changefreq: monthly
-*/
+```
 
 MDWeb is painstakingly designed to be as minimalistic as possible while 
 taking less than 5 minutes to setup and less than a minute to add 

--- a/demo-content/about/license.md
+++ b/demo-content/about/license.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: MDWeb License
 Nav Name: MDWeb License
 Description: MDWeb Opensource License
@@ -7,7 +7,7 @@ Order: 99
 Teaser: MDWeb is released under the MIT license.
 Sitemap Priority: 0.1
 Sitemap Changefreq: never
-*/
+```
 
 ## MDWeb License
 

--- a/demo-content/documentation/Development/events.md
+++ b/demo-content/documentation/Development/events.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: Event Hooks
 Nav Name: Event Hooks
 Description: MDWeb Event Hooks
@@ -7,7 +7,7 @@ Teaser: MDWeb system event hook reference. Useful reference for writing
     plugins.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 #System Event Hooks
 

--- a/demo-content/documentation/Development/navigation.md
+++ b/demo-content/documentation/Development/navigation.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: The Navigation Object
 Nav Name: Navigation Object
 Description: MDWeb Navigation Object
@@ -7,7 +7,7 @@ Teaser: MDWeb navigation object reference. Useful reference for writing
     themes and plugins.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 #Navigation Object
 The navigation object is available within page templates and provides the

--- a/demo-content/documentation/Development/page.md
+++ b/demo-content/documentation/Development/page.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: The Page Object
 Nav Name: Page Object
 Description: MDWeb Page Object
@@ -7,7 +7,7 @@ Teaser: MDWeb page object reference. Useful reference for writing
     themes and plugins.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 #Page Object
 The page object contains all the data related to a page. The rendered page

--- a/demo-content/documentation/devserver.md
+++ b/demo-content/documentation/devserver.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: MDWeb Dev Server
 Nav Name: Dev Server
 Description: How to run the MDWeb in development mode
@@ -7,7 +7,7 @@ Teaser: Learn multiple ways to run MDWeb in a development environment.
     Possibilities include local Flask server, Docker, and more.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 
 #MDWeb Development Server

--- a/demo-content/documentation/markdown/index.md
+++ b/demo-content/documentation/markdown/index.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: MDWeb Markdown
 Nav Name: Dev Server
 Description: How to write Markdown
@@ -7,7 +7,7 @@ Teaser: Learn how to write markdown. This reference should cover almost
     all your markdown needs.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 Markdown Basics
 ================

--- a/demo-content/documentation/quickstart.md
+++ b/demo-content/documentation/quickstart.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: MDWeb Quick Start
 Nav Name: Quick Start
 Description: How to quickly get MDWeb running
@@ -7,7 +7,7 @@ Teaser: Learn how to setup MDWeb in 5 minutes or less. Step-by-step
     instructions are given.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 # Quickstart
 

--- a/demo-content/documentation/writing-content.md
+++ b/demo-content/documentation/writing-content.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: Writing Pages
 Nav Name: Writing Pages
 Description: How to write content for MDWeb
@@ -7,7 +7,7 @@ Teaser: Learn how to write content for your MDWeb site. The navigation
     structure and meta fields are explained and examples are given.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 #Writing MDWeb Content
 

--- a/demo-content/download/index.md
+++ b/demo-content/download/index.md
@@ -1,10 +1,11 @@
-/*
+```metainf
 Title: Download MDWeb
 Description: Download MDWeb
 Nav Name: Download
 Sitemap Priority: 0.9
 Sitemap Changefreq: weekly
-*/
+```
+
 # Download MDWeb
 
 MDWeb is ready for you to use.

--- a/demo-content/examples/embedding-html.md
+++ b/demo-content/examples/embedding-html.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: Embedding HTML Example
 Nav Name: Embedding HTML
 Description: An example of embedding HTML into a page
@@ -7,7 +7,7 @@ Teaser: A helpful example for embedding raw HTML into a content file
     for advanced content rendering.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 # Embedding HTML
 

--- a/demo-content/examples/index.md
+++ b/demo-content/examples/index.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: Markdown Examples
 Nav Name: Markdown Examples
 Description: An example of writing markdown for MDWeb content
@@ -6,7 +6,7 @@ Order: 4
 Teaser: A helpful example of writing markdown for MDWeb content.
 Sitemap Priority: 0.5
 Sitemap Changefreq: monthly
-*/
+```
 
 Examples taken from https://daringfireball.net/projects/markdown/basics
 

--- a/demo-content/index.md
+++ b/demo-content/index.md
@@ -1,4 +1,4 @@
-/*
+```metainf
 Title: MDWeb
 Description: The minimalistic markdown NaCMS
 Order: 1
@@ -6,7 +6,7 @@ Template: page_home.html
 Sitemap Priority: 0.9
 Sitemap Changefreq: daily
 Teaser Image: /contentassets/teaser.png
-*/
+```
 
 MDWeb is a markdown based web site framework.
 

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -19,14 +19,14 @@ If you'd like to learn how to write Markdown I suggest reading [Daring Fireball]
 ## Example about/index.md
 
 
-```
-/*
+~~~
+```metafinf
 Title: About MDWeb
 Description: This description will go in the meta description tag
 Nav Name: About MDWeb
 Sitemap Priority: 0.9
 Sitemap Changefreq: monthly
-*/
+```
 
 MDWeb is painstakingly designed to be as minimalistic as possible while 
 taking less than 5 minutes to setup and less than a minute to add 
@@ -40,7 +40,7 @@ The things I saw during those dark days can not be unseen.
 
 After years of battle, this weary web developmer built himself a tiny
 oasis. This is MDWeb, I hope you find respite in it.
-```
+~~~
 
 ## Navigation Structure
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -82,13 +82,13 @@ To register a meta field in MDWeb core:
 1. Decide on a capital-cased and space separated name to be used in the
 metainf block, for example `Co Author`. This is the field name that
 will be used in markdown files metainf block. For example
-```
-/*
+~~~
+```metainf
 Title: Breaking News
 Author: Jean Luc Picard
 Co Author: Will Riker
-*/
 ```
+~~~
 2 Add an entry to the META_FIELDS dictionary in mdweb/metafields.py.
 This dictionary has the following structure
 ```

--- a/mdweb/Page.py
+++ b/mdweb/Page.py
@@ -15,7 +15,8 @@ from mdweb.Exceptions import (
 URL_PATH_REGEX = r'^%s(?P<path>[^\0]*?)(index)?(\.md)'
 
 #: A regex for extracting meta information (and comments).
-META_INF_REGEX = r'(/\*(?P<metainf>.*)\*/)?(?P<content>.*)'
+# META_INF_REGEX = r'(/\*(?P<metainf>.*)\*/)?(?P<content>.*)'
+META_INF_REGEX = r'(```metainf(?P<metainf>.*?)```)?(?P<content>.*)'
 
 
 class PageMetaInf(MetaInfParser):  # pylint: disable=R0903

--- a/tests/sites.py
+++ b/tests/sites.py
@@ -3,13 +3,13 @@ from datetime import datetime
 from dateutil import parser
 from mdweb.MDSite import MDSite
 
-index_md_file_string = u"""/*
+index_md_file_string = u"""```metainf
 Title: MDWeb
 Description: The minimalistic markdown NaCMS
 Date: February 1st, 2016
 Sitemap Priority: 0.9
 Sitemap ChangeFreq: daily
-*/
+```
 """
 
 layout_file_string = u"""

--- a/tests/test_mdsite.py
+++ b/tests/test_mdsite.py
@@ -209,34 +209,34 @@ class TestSortFilter(unittest.TestCase):
 
     def setUp(self):
         self.page_list = []
-        self.page_list.append(Page('/path/to/story3.md', '/to/story3', u"""/*
+        self.page_list.append(Page('/path/to/story3.md', '/to/story3', u"""```metainf
 Title: Blog Story 3
 Date: 2016/05/12
 Nav Name: Story 3
 Order: 3
-*/
+```
 """))
         self.page_list.append(Page('/path/to/other-page.md', '/to/other-page',
-                                   u"""/*
+                                   u"""```metainf
 Title: Other Story
 Date: 2016/04/02
 Nav Name: Another Story
 Order: 2
-*/
+```
 """))
-        self.page_list.append(Page('/path/to/story2.md', '/to/story2', u"""/*
+        self.page_list.append(Page('/path/to/story2.md', '/to/story2', u"""```metainf
 Title: blog story 2
 Date: 2016/03/21
 Nav Name: Story 1
 Order: 2
-*/
+```
 """))
-        self.page_list.append(Page('/path/to/story1.md', '/to/story1', u"""/*
+        self.page_list.append(Page('/path/to/story1.md', '/to/story1', u"""```metainf
 Title: Blog Story 1
 Date: 2016/02/01
 Nav Name: Story 1
 Order: 1
-*/
+```
 """))
 
     def test_sort_title(self):

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -570,34 +570,34 @@ Order: -34
                            contents='Order: 7')
 
         self.fs.create_file('/my/content/index.md')
-        self.fs.create_file('/my/content/about/index.md', contents='''/*
+        self.fs.create_file('/my/content/about/index.md', contents='''```metainf
                             Order: 5
-                            */''')
-        self.fs.create_file('/my/content/contact/index.md', contents='''/*
+                            ```''')
+        self.fs.create_file('/my/content/contact/index.md', contents='''```metainf
                             Order: 10
-                            */''')
-        self.fs.create_file('/my/content/contact/westcoast.md', contents='''/*
+                            ```''')
+        self.fs.create_file('/my/content/contact/westcoast.md', contents='''```metainf
                             Order: 6
-                            */''')
-        self.fs.create_file('/my/content/contact/eastcoast.md', contents='''/*
+                            ```''')
+        self.fs.create_file('/my/content/contact/eastcoast.md', contents='''```metainf
                             Order: 3
-                            */''')
+                            ```''')
         self.fs.create_file('/my/content/work/portfolio/index.md',
-                           contents='''/*
+                           contents='''```metainf
                            Order: 9
-                           */''')
+                           ```''')
         self.fs.create_file('/my/content/work/portfolio/landscapes.md',
-                           contents='''/*
+                           contents='''```metainf
                             Order: 10
-                            */''')
+                            ```''')
         self.fs.create_file('/my/content/work/portfolio/portraits.md',
-                           contents='''/*
+                           contents='''```metainf
                             Order: 11
-                            */''')
+                            ```''')
         self.fs.create_file('/my/content/work/portfolio/nature.md',
-                           contents='''/*
+                           contents='''```metainf
                             Order: 8
-                            */''')
+                            ```''')
 
         nav = Navigation('/my/content')
 

--- a/tests/test_sitemapview.py
+++ b/tests/test_sitemapview.py
@@ -34,13 +34,13 @@ class TestSiteMapView(fake_filesystem_unittest.TestCase, TestCase):
         self.setUpPyfakefs()
         self.fake_os = fake_filesystem.FakeOsModule(self.fs)
 
-        file_string = u"""/*
+        file_string = u"""```metainf
 Title: MDWeb
 Description: The minimalistic markdown NaCMS
 Date: February 1st, 2016
 Sitemap Priority: 0.9
 Sitemap ChangeFreq: daily
-*/
+```
 """
 
         self.fs.create_file('/my/content/400.md')


### PR DESCRIPTION
**BREAKING CHANGE!!!**

Update the meta-inf delimiter from `\*` to triple ticks.

Fixed regex to allow that delimiter to exist but be ignored after the start of the file.

Fixes #47 